### PR TITLE
Use HTTP over TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ UBUNTU_VERSION := 18.04
 UBUNTU_ISO_NAME := ubuntu-$(UBUNTU_VERSION)-desktop-amd64.iso
 
 #UBUNTU_MIRROR := http://releases.ubuntu.com/
-UBUNTU_MIRROR := http://ftp.rediris.es/sites/releases.ubuntu.com/
+UBUNTU_MIRROR := https://ftp.rediris.es/sites/releases.ubuntu.com/
 
 UBUNTU_BASE_URL := $(UBUNTU_MIRROR)$(UBUNTU_VERSION)
 DOWNLOAD_FILES := SHA256SUMS SHA256SUMS.gpg $(UBUNTU_ISO_NAME)


### PR DESCRIPTION
GNUPG already verifies authenticity, but anyway. Rediris FTP has a valid TLS certificate, so why not use it.